### PR TITLE
Enabled component instantiation in Railo 4.2

### DIFF
--- a/timezone.cfc
+++ b/timezone.cfc
@@ -482,7 +482,7 @@ methods in this CFC:
 	
 		if (isValidTZ(aTZ))
 		{
-			aTZStruct.Entry[aTZ].Detail = getTimeZone(aTZ);
+			aTZStruct.Entry[aTZ].Detail = this.getTimeZone(aTZ);
 		}
 		else
 		{


### PR DESCRIPTION
getTimeZone() conflicts with Railo's BIF function. Using <em>this.</em>getTimeZone() to scope the function call to the custom component.
